### PR TITLE
Disable ACL by default in DragonflyDB instance Helm chart

### DIFF
--- a/charts/dragonflydb-instance/README.md
+++ b/charts/dragonflydb-instance/README.md
@@ -16,7 +16,10 @@ dragonflydb-instance Helm chart
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | acl | object | `{"enabled":false,"existingSecret":"","key":"","optional":false,"rules":""}` | Access Control List (ACL) configuration |
-| acl.enabled | bool | `false` | Enable ACL |
+| acl.enabled | bool | `false` | Enable ACL Note: When ACL is enabled, you must provide ACL rules either through 'rules' or 'existingSecret'. DragonflyDB will not start properly if ACL is enabled but no rules are provided. |
+| acl.existingSecret | string | `""` | Name of existing secret containing the ACL rules If empty, a new secret will be created |
+| acl.key | string | `""` | The key to use for the ACL rules in the secret |
+| acl.optional | bool | `false` | If true, the ACL rules will be optional |
 | acl.rules | string | `""` | The ACL rules to apply to the database if existingSecret is empty @see https://www.dragonflydb.io/docs/managing-dragonfly/acl Example: rules: |   user user on >pass ~* &* +@string +@fast -@slow +set   user rouser on >ropass ~* &* +@read |
 | affinity | object | `{}` | Affinity rules for pod assignment @see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
 | args | list | `[]` | DragonflyDB configuration flags @see https://www.dragonflydb.io/docs/managing-dragonfly/flags |

--- a/charts/dragonflydb-instance/README.md
+++ b/charts/dragonflydb-instance/README.md
@@ -15,8 +15,8 @@ dragonflydb-instance Helm chart
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| acl | object | `{"enabled":true,"existingSecret":"","key":"","optional":false,"rules":""}` | Access Control List (ACL) configuration |
-| acl.enabled | bool | `true` | Enable ACL |
+| acl | object | `{"enabled":false,"existingSecret":"","key":"","optional":false,"rules":""}` | Access Control List (ACL) configuration |
+| acl.enabled | bool | `false` | Enable ACL |
 | acl.rules | string | `""` | The ACL rules to apply to the database if existingSecret is empty @see https://www.dragonflydb.io/docs/managing-dragonfly/acl Example: rules: |   user user on >pass ~* &* +@string +@fast -@slow +set   user rouser on >ropass ~* &* +@read |
 | affinity | object | `{}` | Affinity rules for pod assignment @see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
 | args | list | `[]` | DragonflyDB configuration flags @see https://www.dragonflydb.io/docs/managing-dragonfly/flags |

--- a/charts/dragonflydb-instance/values.yaml
+++ b/charts/dragonflydb-instance/values.yaml
@@ -114,7 +114,7 @@ pdb:
 # -- Access Control List (ACL) configuration
 acl:
   # -- Enable ACL
-  enabled: true
+  enabled: false
   # If empty, a new secret will be created
   existingSecret: ""
   # If true, the ACL rules will be optional

--- a/charts/dragonflydb-instance/values.yaml
+++ b/charts/dragonflydb-instance/values.yaml
@@ -114,12 +114,15 @@ pdb:
 # -- Access Control List (ACL) configuration
 acl:
   # -- Enable ACL
+  # Note: When ACL is enabled, you must provide ACL rules either through 'rules' or 'existingSecret'.
+  # DragonflyDB will not start properly if ACL is enabled but no rules are provided.
   enabled: false
+  # -- Name of existing secret containing the ACL rules
   # If empty, a new secret will be created
   existingSecret: ""
-  # If true, the ACL rules will be optional
+  # -- If true, the ACL rules will be optional
   optional: false
-  # The key to use for the ACL rules in the secret
+  # -- The key to use for the ACL rules in the secret
   key: ""
   # -- The ACL rules to apply to the database if existingSecret is empty
   # @see https://www.dragonflydb.io/docs/managing-dragonfly/acl


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

Need to disable the acl value because spinning up a dragonfly cluster with default values fails on dragonfly trying to find valid acls. 

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->
